### PR TITLE
Use select() syscall to avoid busy waiting

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -156,6 +156,9 @@ class Requests_Transport_cURL implements Requests_Transport {
 		do {
 			$active = false;
 
+			if ($active) {
+				curl_multi_select($multihandle);
+			}
 			do {
 				$status = curl_multi_exec($multihandle, $active);
 			}


### PR DESCRIPTION
Currently it consumes a lot of CPU, it's a no-brainer i think.
