### PR TITLE
Add `Requests::has_capability()` which can be used to determine if SSL is available.

### DIFF
--- a/library/Requests.php
+++ b/library/Requests.php
@@ -217,6 +217,21 @@ class Requests {
 		return new self::$transport[$cap_string]();
 	}
 
+	/**
+	 * Checks to see if we have a transport for the capabilities requested.
+	 *
+	 * @return bool
+	 */
+	public static function has_capability($capabilities = array()) {
+		try {
+			$transport = self::get_transport($capabilities);
+		} catch(Requests_Exception $e) {
+			return false;
+		}
+
+		return true;
+	}
+
 	/**#@+
 	 * @see request()
 	 * @param string $url

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -225,7 +225,7 @@ class Requests {
 	public static function has_capability($capabilities = array()) {
 		try {
 			$transport = self::get_transport($capabilities);
-		} catch(Requests_Exception $e) {
+		} catch (Requests_Exception $e) {
 			return false;
 		}
 


### PR DESCRIPTION
Add `Requests::has_capability()` which can be used to determine if SSL is available.

An example of it's usage: `Requests::has_capability( array( 'ssl' => true ) );`

See #250 
