### PR TITLE
max_bytes not respected in a performant manner

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -166,12 +166,12 @@ class Requests_Transport_cURL implements Requests_Transport {
 
 		$curl_errno = curl_errno($this->handle);
 
-		if ( $curl_errno === 23 && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes ) {
+		if ($curl_errno === 23 && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes) {
 			// CURLE_WRITE_ERROR - Not actually an error in this case. We've drained as much data from the request that we want.
 			$curl_errno = false;
 		}
 
-		if ( $curl_errno === 23 || $curl_errno === 61) {
+		if ($curl_errno === 23 || $curl_errno === 61) {
 			// Reset encoding and try again
 			curl_setopt($this->handle, CURLOPT_ENCODING, 'none');
 
@@ -421,7 +421,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 		}
 
 		$curl_errno = curl_errno($this->handle);
-		if ( $curl_errno === 23 && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes ) {
+		if ($curl_errno === 23 && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes) {
 			// CURLE_WRITE_ERROR - Not actually an error in this case. We've drained as much data from the request that we want.
 			$curl_errno = false;
 		}

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -164,7 +164,14 @@ class Requests_Transport_cURL implements Requests_Transport {
 
 		$options['hooks']->dispatch('curl.after_send', array());
 
-		if (curl_errno($this->handle) === 23 || curl_errno($this->handle) === 61) {
+		$curl_errno = curl_errno($this->handle);
+
+		if ( $curl_errno === 23 && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes ) {
+			// CURLE_WRITE_ERROR - Not actually an error in this case. We've drained as much data from the request that we want.
+			$curl_errno = false;
+		}
+
+		if ( $curl_errno === 23 || $curl_errno === 61) {
 			// Reset encoding and try again
 			curl_setopt($this->handle, CURLOPT_ENCODING, 'none');
 
@@ -413,7 +420,13 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$this->headers .= $response;
 		}
 
-		if (curl_errno($this->handle)) {
+		$curl_errno = curl_errno($this->handle);
+		if ( $curl_errno === 23 && $this->response_byte_limit && $this->response_byte_limit === $this->response_bytes ) {
+			// CURLE_WRITE_ERROR - Not actually an error in this case. We've drained as much data from the request that we want.
+			$curl_errno = false;
+		}
+
+		if ($curl_errno) {
 			$error = sprintf(
 				'cURL error %s: %s',
 				curl_errno($this->handle),
@@ -465,15 +478,10 @@ class Requests_Transport_cURL implements Requests_Transport {
 
 		// Are we limiting the response size?
 		if ($this->response_byte_limit) {
-			if ($this->response_bytes === $this->response_byte_limit) {
-				// Already at maximum, move on
-				return $data_length;
-			}
-
 			if (($this->response_bytes + $data_length) > $this->response_byte_limit) {
 				// Limit the length
-				$limited_length = ($this->response_byte_limit - $this->response_bytes);
-				$data = substr($data, 0, $limited_length);
+				$data_length = ($this->response_byte_limit - $this->response_bytes);
+				$data = substr($data, 0, $data_length);
 			}
 		}
 
@@ -484,7 +492,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$this->response_data .= $data;
 		}
 
-		$this->response_bytes += strlen($data);
+		$this->response_bytes += $data_length;
 		return $data_length;
 	}
 

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -257,23 +257,24 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 				$options['hooks']->dispatch('request.progress', array($block, $size, $this->max_bytes));
 				$data_length = strlen($block);
 				if ($this->max_bytes) {
-					// Have we already hit a limit?
-					if ($size === $this->max_bytes) {
-						continue;
-					}
 					if (($size + $data_length) > $this->max_bytes) {
 						// Limit the length
-						$limited_length = ($this->max_bytes - $size);
-						$block = substr($block, 0, $limited_length);
+						$data_length = ($this->max_bytes - $size);
+						$block = substr($block, 0, $data_length);
 					}
 				}
 
-				$size += strlen($block);
+				$size += $data_length;
 				if ($download) {
 					fwrite($download, $block);
 				}
 				else {
 					$body .= $block;
+				}
+
+				// Have we hit a limit?
+				if ($this->max_bytes && $size === $this->max_bytes) {
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
With some testing I was noticing that a request for 100 byes from a 10MB file was timing out after 5 seconds.

Turns out that the cause was that Requests downloads the full 10MB file in order to return the first 100 bytes of it.

This PR simply aborts the connection when enough bytes have been read from the stream.