### PR TITLE
Throw exception if invalid filename is provided

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -156,7 +156,11 @@ class Requests_Transport_cURL implements Requests_Transport {
 		$options['hooks']->dispatch('curl.before_send', array(&$this->handle));
 
 		if ($options['filename'] !== false) {
-			$this->stream_handle = fopen($options['filename'], 'wb');
+			@$this->stream_handle = fopen($options['filename'], 'wb');
+			if($this->stream_handle===false) {
+				$error = error_get_last();
+				throw new Requests_Exception($error['message'], 'fopen');
+			}
 		}
 
 		$this->response_data       = '';

--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -156,8 +156,9 @@ class Requests_Transport_cURL implements Requests_Transport {
 		$options['hooks']->dispatch('curl.before_send', array(&$this->handle));
 
 		if ($options['filename'] !== false) {
-			@$this->stream_handle = fopen($options['filename'], 'wb');
-			if($this->stream_handle===false) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors -- Silenced the PHP native warning in favour of throwing an exception.
+			$this->stream_handle = @fopen($options['filename'], 'wb');
+			if ($this->stream_handle === false) {
 				$error = error_get_last();
 				throw new Requests_Exception($error['message'], 'fopen');
 			}

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -260,7 +260,11 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		$doingbody  = false;
 		$download   = false;
 		if ($options['filename']) {
-			$download = fopen($options['filename'], 'wb');
+			@$download = fopen($options['filename'], 'wb');
+			if($download===false) {
+				$error = error_get_last();
+				throw new Requests_Exception($error['message'], 'fopen');
+			}
 		}
 
 		while (!feof($socket)) {

--- a/library/Requests/Transport/fsockopen.php
+++ b/library/Requests/Transport/fsockopen.php
@@ -260,8 +260,9 @@ class Requests_Transport_fsockopen implements Requests_Transport {
 		$doingbody  = false;
 		$download   = false;
 		if ($options['filename']) {
-			@$download = fopen($options['filename'], 'wb');
-			if($download===false) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors -- Silenced the PHP native warning in favour of throwing an exception.
+			$download = @fopen($options['filename'], 'wb');
+			if ($download === false) {
 				$error = error_get_last();
 				throw new Requests_Exception($error['message'], 'fopen');
 			}

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -609,12 +609,18 @@ abstract class BaseTestCase extends TestCase {
 		unlink($filename);
 	}
 
+	/**
+	 * @expectedException        Requests_Exception
+	 * @expectedExceptionMessage failed to open stream: No such file or directory
+	 */
 	public function testStreamToInvalidFile() {
 		$options = array(
 			'filename' => tempnam(sys_get_temp_dir(), 'RLT').'/missing/directory' // RequestsLibraryTest
 		);
+		/*Assertions for PHPUnit 6+
 		$this->expectException(Requests_Exception::class);
 		$this->expectExceptionMessage('failed to open stream: No such file or directory');
+		*/
 		Requests::get(httpbin('/get'), array(), $this->getOptions($options));
 	}
 

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -609,18 +609,14 @@ abstract class BaseTestCase extends TestCase {
 		unlink($filename);
 	}
 
-	/**
-	 * @expectedException        Requests_Exception
-	 * @expectedExceptionMessage failed to open stream
-	 */
 	public function testStreamToInvalidFile() {
 		$options = array(
-			'filename' => tempnam(sys_get_temp_dir(), 'RLT').'/missing/directory' // RequestsLibraryTest
+			'filename' => tempnam(sys_get_temp_dir(), 'RLT') . '/missing/directory', // RequestsLibraryTest
 		);
-		/*Assertions for PHPUnit 6+
+
 		$this->expectException(Requests_Exception::class);
-		$this->expectExceptionMessage('failed to open stream: No such file or directory');
-		*/
+		$this->expectExceptionMessage('failed to open stream');
+
 		Requests::get(httpbin('/get'), array(), $this->getOptions($options));
 	}
 

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -611,7 +611,7 @@ abstract class BaseTestCase extends TestCase {
 
 	/**
 	 * @expectedException        Requests_Exception
-	 * @expectedExceptionMessage failed to open stream: No such file or directory
+	 * @expectedExceptionMessage failed to open stream
 	 */
 	public function testStreamToInvalidFile() {
 		$options = array(

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -586,6 +586,9 @@ abstract class BaseTestCase extends TestCase {
 		unlink($options['filename']);
 	}
 
+	/**
+	 * Verify that a stream to a non-writable file fails and leaves the file unchanged.
+	 */
 	public function testStreamToNonWritableFile() {
 		// Create an unwritable file.
 		$filename = tempnam(sys_get_temp_dir(), 'RLT'); // RequestsLibraryTest
@@ -597,10 +600,13 @@ abstract class BaseTestCase extends TestCase {
 			'filename' => $filename,
 		);
 
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors -- Silencing "failed to open stream" warning.
-		$request = @Requests::get(httpbin('/get'), array(), $this->getOptions($options));
-		$this->assertSame(200, $request->status_code);
-		$this->assertEmpty($request->body);
+		try {
+			Requests::get(httpbin('/get'), array(), $this->getOptions($options));
+
+			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		} catch (Requests_Exception $e) {
+			// This "Failed to open stream" exception is expected.
+		}
 
 		$contents = file_get_contents($options['filename']);
 		$this->assertSame('foo', $contents);
@@ -609,13 +615,17 @@ abstract class BaseTestCase extends TestCase {
 		unlink($filename);
 	}
 
+	/**
+	 * Verify that a stream to an invalid file fails.
+	 */
 	public function testStreamToInvalidFile() {
 		$options = array(
 			'filename' => tempnam(sys_get_temp_dir(), 'RLT') . '/missing/directory', // RequestsLibraryTest
 		);
 
 		$this->expectException(Requests_Exception::class);
-		$this->expectExceptionMessage('failed to open stream');
+		// First character (F) can be upper or lowercase depending on PHP version.
+		$this->expectExceptionMessage('ailed to open stream');
 
 		Requests::get(httpbin('/get'), array(), $this->getOptions($options));
 	}

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -609,6 +609,15 @@ abstract class BaseTestCase extends TestCase {
 		unlink($filename);
 	}
 
+	public function testStreamToInvalidFile() {
+		$options = array(
+			'filename' => tempnam(sys_get_temp_dir(), 'RLT').'/missing/directory' // RequestsLibraryTest
+		);
+		$this->expectException(Requests_Exception::class);
+		$this->expectExceptionMessage('failed to open stream: No such file or directory');
+		Requests::get(httpbin('/get'), array(), $this->getOptions($options));
+	}
+
 	public function testNonblocking() {
 		$options = array(
 			'blocking' => false,


### PR DESCRIPTION
Throw an exception if an invalid path is provided in the filename option.
Before this change, the script will continue and try to write and close a file pointer which does not exist.