### PR TITLE
 Replace where relevant the occurrences of "https://github.com/rmccue/Requests/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requests for PHP
 Requests is a HTTP library written in PHP, for human beings. It is roughly
 based on the API from the excellent [Requests Python
 library](http://python-requests.org/). Requests is [ISC
-Licensed](https://github.com/rmccue/Requests/blob/master/LICENSE) (similar to
+Licensed](https://github.com/WordPress/Requests/blob/master/LICENSE) (similar to
 the new BSD license) and has no dependencies, except for PHP 5.2+.
 
 Despite PHP's use as a language for the web, its tools for sending HTTP requests
@@ -116,9 +116,9 @@ documented.
 
 Requests is [100% documented with PHPDoc](http://requests.ryanmccue.info/api/).
 If you find any problems with it, [create a new
-issue](https://github.com/rmccue/Requests/issues/new)!
+issue](https://github.com/WordPress/Requests/issues/new)!
 
-[prose-based documentation]: https://github.com/rmccue/Requests/blob/master/docs/README.md
+[prose-based documentation]: https://github.com/WordPress/Requests/blob/master/docs/README.md
 [request_method]: http://requests.ryanmccue.info/api/class-Requests.html#_request
 
 Testing
@@ -149,4 +149,4 @@ Contribute
 3. Write a test which shows that the bug was fixed or that the feature works as expected
 4. Send a pull request and bug me until I merge it
 
-[the repository]: https://github.com/rmccue/Requests
+[the repository]: https://github.com/WordPress/Requests

--- a/docs/why-requests.md
+++ b/docs/why-requests.md
@@ -64,7 +64,7 @@ Why should I use Requests?
 
 [coveralls]: https://coveralls.io/r/rmccue/Requests
 [hooking system]: hooks.md
-[requests_ssl]: https://github.com/rmccue/Requests/blob/master/library/Requests/SSL.php
+[requests_ssl]: https://github.com/WordPress/Requests/blob/master/library/Requests/SSL.php
 [travis]: https://travis-ci.org/rmccue/Requests
 [wpssl]: http://core.trac.wordpress.org/ticket/25007
 


### PR DESCRIPTION
Fixes #440.

Replace where relevant the occurrences of "https://github.com/rmccue/Requests/" in the documentation

