### PR TITLE
Removed CURLOPT_REFERER

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -412,7 +412,6 @@ class Requests_Transport_cURL implements Requests_Transport {
 			curl_setopt($this->handle, CURLOPT_CONNECTTIMEOUT_MS, round($options['connect_timeout'] * 1000));
 		}
 		curl_setopt($this->handle, CURLOPT_URL, $url);
-		curl_setopt($this->handle, CURLOPT_REFERER, $url);
 		curl_setopt($this->handle, CURLOPT_USERAGENT, $options['useragent']);
 		if (!empty($headers)) {
 			curl_setopt($this->handle, CURLOPT_HTTPHEADER, $headers);


### PR DESCRIPTION
Hey,

as stated in the curl docs https://everything.curl.dev/libcurl-http/requests#referrer

the Referer is a header that tells the server from which URL the user-agent was directed from.

So imho this shouldn't be the request's target url.