### PR TITLE
Add shebangs to proxy shell scripts

### DIFF
--- a/tests/utils/proxy/start.sh
+++ b/tests/utils/proxy/start.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 PROXYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PORT=${PORT:-9000}
 

--- a/tests/utils/proxy/stop.sh
+++ b/tests/utils/proxy/stop.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 PROXYDIR="$PWD/$(dirname $0)"
 
 PIDFILE="$PROXYDIR/proxy.pid"


### PR DESCRIPTION
Without proper shebangs in the shell script, some systems assume lowest common denominator of `sh` for compatibility reasons.

This breaks with the testing logic in the current scripts:

<img width="541" alt="~_dev_Requests 2021-02-09 at 9 31 46 AM" src="https://user-images.githubusercontent.com/83631/107344164-11cc6000-6aba-11eb-9c90-05d50b046854.png">

This PR adds a shebang to the scripts to use `bash` as the executable shell instead.