### PR TITLE
Requests_Transport_cURL - fix PHP 8.0 issue with filename verification

### DIFF
--- a/library/Requests/Transport/cURL.php
+++ b/library/Requests/Transport/cURL.php
@@ -411,7 +411,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 			$options['hooks']->dispatch('curl.after_request', array(&$fake_headers));
 			return false;
 		}
-		if ($options['filename'] !== false) {
+		if ($options['filename'] !== false && $this->stream_handle) {
 			fclose($this->stream_handle);
 			$this->headers = trim($this->headers);
 		}

--- a/tests/Transport/Base.php
+++ b/tests/Transport/Base.php
@@ -530,6 +530,29 @@ abstract class RequestsTest_Transport_Base extends PHPUnit_Framework_TestCase {
 		unlink($options['filename']);
 	}
 
+	public function testStreamToNonWritableFile() {
+		// Create an unwritable file.
+		$filename = tempnam(sys_get_temp_dir(), 'RLT'); // RequestsLibraryTest
+		if (file_put_contents($filename, 'foo')) {
+			chmod($filename, 0444);
+		}
+
+		$options = array(
+			'filename' => $filename,
+		);
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors -- Silencing "failed to open stream" warning.
+		$request = @Requests::get(httpbin('/get'), array(), $this->getOptions($options));
+		$this->assertSame(200, $request->status_code);
+		$this->assertEmpty($request->body);
+
+		$contents = file_get_contents($options['filename']);
+		$this->assertSame('foo', $contents);
+
+		chmod($filename, 0755);
+		unlink($filename);
+	}
+
 	public function testNonblocking() {
 		$options = array(
 			'blocking' => false,


### PR DESCRIPTION
Fixes #432

This prevents the fatal `TypeError` on PHP 8.0 and maintains the existing behaviour as it was on previous PHP versions.

Includes dedicated test. The test will pass on PHP < 8 and fail on PHP 8 without this fix and pass on all supported PHP versions with the fix.