### PR TITLE
FilteredIterator: fix PHP 5.2/5.3 compatibility and actually run the tests

### DIFF
--- a/library/Requests/Utility/FilteredIterator.php
+++ b/library/Requests/Utility/FilteredIterator.php
@@ -39,7 +39,11 @@ class Requests_Utility_FilteredIterator extends ArrayIterator {
 	 */
 	public function current() {
 		$value = parent::current();
-		$value = call_user_func($this->callback, $value);
+
+		if (is_callable($this->callback)) {
+			$value = call_user_func($this->callback, $value);
+		}
+
 		return $value;
 	}
 

--- a/tests/Utility/FilteredIterator.php
+++ b/tests/Utility/FilteredIterator.php
@@ -9,8 +9,8 @@ class RequestsTest_Utility_FilteredIterator extends PHPUnit_Framework_TestCase {
 		if (get_class($value) === 'Requests_Utility_FilteredIterator') {
 			$new_value = unserialize($serialized);
 			if (version_compare(PHP_VERSION, '5.3', '>=')) {
-				// phpcs:ignore PHPCompatibility.Syntax.NewClassMemberAccess.OnNewFound -- Wrapped in version check.
-				$property = (new ReflectionClass('Requests_Utility_FilteredIterator'))->getProperty('callback');
+				$reflection = new ReflectionClass('Requests_Utility_FilteredIterator');
+				$property   = $reflection->getProperty('callback');
 				$property->setAccessible(true);
 				$callback_value = $property->getValue($new_value);
 				$this->assertSame(null, $callback_value);

--- a/tests/Utility/FilteredIterator.php
+++ b/tests/Utility/FilteredIterator.php
@@ -27,6 +27,7 @@ class RequestsTest_Utility_FilteredIterator extends PHPUnit_Framework_TestCase {
 		return array(
 			array(new Requests_Utility_FilteredIterator(array(1), 'md5')),
 			array(new Requests_Utility_FilteredIterator(array(1, 2), 'sha1')),
+			array(new Requests_Utility_FilteredIterator(array(1, 2, 3), 'doesnotexist')),
 			array(new ArrayIterator(array(1, 2, 3))),
 		);
 	}

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -27,6 +27,7 @@
 			<file>Response/Headers.php</file>
 			<file>Session.php</file>
 			<file>SSL.php</file>
+			<file>Utility/FilteredIterator.php</file>
 		</testsuite>
 	</testsuites>
 


### PR DESCRIPTION
### FilteredIterator: fix PHP 5.2 compatibility and stabilize the code

The `$callback` passed to the constructor of the `FilteredIterator` class may not be callable and if so, would cause a fatal error.

This puts some defensive coding in place to guard against that and adds a unit test for it as well.

This also fixes the tests failing on PHP 5.2, as when the object is unserialized on PHP 5.2, the `$callback` property will no longer be set. This looks to have been a bug in PHP 5.2 which was fixed in PHP 5.3.

### Tests/FilteredIterator: fix a parse error on PHP 5.3

Even though the code is wrapped in a version check for running, the code still needs to parse correctly on low PHP versions.

This was not the case now, which could break the running of the tests of PHP 5.3.

Fixed now.

### Tests: actually run the test for the FilteredIterator

As all tests are explicitly named in the test configuration, the  test for the `FilteredIterator` as added in #422 were not being run as they hadn't been added to the config.

This fixes that.