### PR TITLE
Travis: fix PHP 8.0 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
     travis_retry composer remove --dev --no-update squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
    fi
  - |
-   if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+   if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer install --no-interaction --ignore-platform-reqs
    else
     travis_retry composer install --no-interaction


### PR DESCRIPTION
Follow up on #439

Even though we'll soon be moving to GH Actions, I think it is important to fix the failing build on PHP 8.0 ahead of this and ahead of the 1.8.0 release, as otherwise any badges in the README, on Packagist and on the website, will show the CI build as failing until we release version 2.0.0 and that wouldn't be right.