### PR TITLE
CodeCov: add configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  round: nearest
+  # Status will be green when coverage is between 85 and 100%.
+  range: "85...100"
+  status:
+    project:
+      default:
+        threshold: 1%
+        paths:
+          - "library"
+    patch:
+      default:
+        threshold: 0%
+        paths:
+          - "library"
+
+comment: false

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,0 @@
-src_dir: library
-coverage_clover: tests/clover.xml
-json_path: tests/coveralls.json
-service_name: travis-ci


### PR DESCRIPTION
This commit:
* Removes the configuration for the Coverall service which is no longer used.
* Adds a configuration for the CodeCov service (which _is_ used).
    This configuration:
    - Adds a threshold of a 1% difference before failing the build for project status checks (= total coverage for the whole project).
        Too often, due to some imprecision in how the code coverage is calculated, a difference of `-0.12%` (or similar) will be reported.
        That kind of difference is no a reason to fail the build and block merges as it is often incorrect anyhow. (how can a docs PR cause a negative code coverage diff ?)
    - Explicitly sets the path for which files we expect to be covered.
    - For patch status checks the threshold remains at 0% (which is the default), meaning that the code coverage is not allowed to go down for the lines touched in the patch.
    - Turns off in the inane PR comments. The status checks are sufficient, the huge comments on each PR do not add much value.