### PR TITLE
CI: switch to GitHub Actions for PHP 5.5 - current

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
+codecov:
+    notify:
+        after_n_builds: 2
+
 coverage:
   round: nearest
   # Status will be green when coverage is between 85 and 100%.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+.github/ export-ignore
 bin/ export-ignore
 docs/ export-ignore
 examples/ export-ignore

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,0 +1,37 @@
+name: CS
+
+on:
+  # Run on all pushes and on all pull requests.
+  push:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  phpcs: #----------------------------------------------------------------------
+    name: 'PHPCS'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: cs2pr
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
+
+      # Check the code-style consistency of the PHP files.
+      - name: Check PHP code style
+        continue-on-error: true
+        run: composer checkcs -- --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,45 @@
+name: Lint
+
+on:
+  # Run on all pushes and on all pull requests.
+  push:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  lint: #----------------------------------------------------------------------
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Lint against the high/low versions of each PHP major and select additional versions.
+        # Note: linting against PHP 5.2 , 5.3 and 5.4 is still done via Travis.
+        php: ['5.6', '7.0', '7.4', '8.0']
+        experimental: [false]
+
+        include:
+          - php: '8.1'
+            experimental: true
+
+    name: "Lint: PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: cs2pr
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
+
+      - name: Lint against parse errors
+        run: composer lint -- --checkstyle | cs2pr

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -1,0 +1,96 @@
+name: Quicktest
+
+on:
+  push:
+    branches-ignore:
+      - master
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  #### QUICK TEST STAGE ####
+  # Runs the tests against select PHP versions for pushes to arbitrary branches.
+  quicktest:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['5.5', '7.2', 'latest']
+
+    name: "Quick Test: PHP ${{ matrix.php }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies - normal
+        if: ${{ startsWith( matrix.php, '8' ) == false && matrix.php != 'latest' }}
+        uses: "ramsey/composer-install@v1"
+
+      # For PHP 8.0 and "nightly", we need to install with ignore platform reqs.
+      - name: Install Composer dependencies - with ignore platform
+        if: ${{ startsWith( matrix.php, '8' ) || matrix.php == 'latest' }}
+        uses: "ramsey/composer-install@v1"
+        with:
+          composer-options: --ignore-platform-reqs
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Setup proxy server
+        run: pip3 install mitmproxy
+
+      - name: Start test server
+        run: |
+          PORT=8080 vendor/bin/start.sh
+          echo "REQUESTS_TEST_HOST_HTTP=localhost:8080" >> $GITHUB_ENV
+
+      - name: Start proxy server
+        run: |
+          PORT=9002 tests/utils/proxy/start.sh
+          PORT=9003 AUTH="test:pass" tests/utils/proxy/start.sh
+          echo "REQUESTS_HTTP_PROXY=localhost:9002" >> $GITHUB_ENV
+          echo "REQUESTS_HTTP_PROXY_AUTH=localhost:9003" >> $GITHUB_ENV
+          echo "REQUESTS_HTTP_PROXY_AUTH_USER=test" >> $GITHUB_ENV
+          echo "REQUESTS_HTTP_PROXY_AUTH_PASS=pass" >> $GITHUB_ENV
+
+      - name: Ensure the HTTPS test instance on Heroku is spun up
+        run: curl -s -I http://requests-php-tests.herokuapp.com/ > /dev/null
+
+      - name: Check mitmproxy version
+        run: mitmdump --version
+
+      - name: Ping localhost domain
+        run: ping -c1 localhost
+
+      - name: Access localhost on port 8080
+        run: curl -i http://localhost:8080
+
+      - name: Access localhost on port 9002
+        run: curl -i http://localhost:9002
+
+      - name: Show PHPUnit version
+        run: vendor/bin/phpunit --version
+
+      - name: Run the unit tests
+        run: composer test
+
+      - name: Stop proxy server
+        continue-on-error: true
+        run: |
+          PORT=9002 tests/utils/proxy/stop.sh
+          PORT=9003 tests/utils/proxy/stop.sh
+
+      - name: Stop test server
+        continue-on-error: true
+        run: vendor/bin/stop.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,144 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  #### TEST STAGE ####
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Keys:
+      # - coverage: Whether to run the tests with code coverage.
+      # - experimental: Whether the build is "allowed to fail".
+      matrix:
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        coverage: [false]
+        experimental: [false]
+
+        include:
+          # Run code coverage on high/low PHP.
+          - php: '5.5'
+            coverage: true
+            experimental: false
+          - php: '8.0'
+            coverage: true
+            experimental: false
+
+          # Test against PHP Nightly.
+          # This should be enabled once the PHPUnit version constraints have been widened.
+          #- php: '8.1'
+          #  coverage: false
+          #  experimental: true
+
+    name: "Test: PHP ${{ matrix.php }}"
+
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set coverage variable
+        id: set_cov
+        run: |
+          if [ ${{ matrix.coverage }} == "true" ]; then
+            echo '::set-output name=COV::xdebug'
+          else
+            echo '::set-output name=COV::none'
+          fi
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: ${{ steps.set_cov.outputs.COV }}
+          tools: cs2pr
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies - normal
+        if: ${{ startsWith( matrix.php, '8' ) == false && matrix.php != 'latest' }}
+        uses: "ramsey/composer-install@v1"
+
+      # For PHP 8.0 and "nightly", we need to install with ignore platform reqs.
+      - name: Install Composer dependencies - with ignore platform
+        if: ${{ startsWith( matrix.php, '8' ) || matrix.php == 'latest' }}
+        uses: "ramsey/composer-install@v1"
+        with:
+          composer-options: --ignore-platform-reqs
+
+      - name: Setup problem matcher to provide annotations for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Setup proxy server
+        run: pip3 install mitmproxy
+
+      - name: Start test server
+        run: |
+          PORT=8080 vendor/bin/start.sh
+          echo "REQUESTS_TEST_HOST_HTTP=localhost:8080" >> $GITHUB_ENV
+
+      - name: Start proxy server
+        run: |
+          PORT=9002 tests/utils/proxy/start.sh
+          PORT=9003 AUTH="test:pass" tests/utils/proxy/start.sh
+          echo "REQUESTS_HTTP_PROXY=localhost:9002" >> $GITHUB_ENV
+          echo "REQUESTS_HTTP_PROXY_AUTH=localhost:9003" >> $GITHUB_ENV
+          echo "REQUESTS_HTTP_PROXY_AUTH_USER=test" >> $GITHUB_ENV
+          echo "REQUESTS_HTTP_PROXY_AUTH_PASS=pass" >> $GITHUB_ENV
+
+      - name: Ensure the HTTPS test instance on Heroku is spun up
+        run: curl -s -I http://requests-php-tests.herokuapp.com/ > /dev/null
+
+      - name: Check mitmproxy version
+        run: mitmdump --version
+
+      - name: Ping localhost domain
+        run: ping -c1 localhost
+
+      - name: Access localhost on port 8080
+        run: curl -i http://localhost:8080
+
+      - name: Access localhost on port 9002
+        run: curl -i http://localhost:9002
+
+      - name: Show PHPUnit version
+        run: vendor/bin/phpunit --version
+
+      - name: Run the unit tests, no code coverage
+        if: ${{ matrix.coverage == false }}
+        run: composer test
+
+      - name: Run the unit tests with code coverage
+        if: ${{ matrix.coverage == true }}
+        run: vendor/bin/phpunit --coverage-clover clover.xml
+
+      - name: Stop proxy server
+        continue-on-error: true
+        run: |
+          PORT=9002 tests/utils/proxy/stop.sh
+          PORT=9003 tests/utils/proxy/stop.sh
+
+      - name: Stop test server
+        continue-on-error: true
+        run: vendor/bin/stop.sh
+
+      - name: Send coverage report to Codecov
+        if: ${{ success() && matrix.coverage == true }}
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./clover.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,15 @@
 dist: xenial
 language: php
 
-env:
-  - COMPOSER_PHPUNIT=true
-
 jobs:
   fast_finish: true
   include:
    - php: 5.2
      dist: precise
-     env: COMPOSER_PHPUNIT=false
    - php: 5.3
      dist: precise
-     env: COMPOSER_PHPUNIT=false
    - php: 5.4
      dist: trusty
-     env: COMPOSER_PHPUNIT=false
-   - php: 5.5
-     dist: trusty
-     env: COMPOSER_PHPUNIT=false
-   - php: 5.6
-     env: TEST_COVERAGE=1
-   - php: 7.0
-   - php: 7.1
-   - php: 7.2
-   - php: 7.3
-   - php: 7.4
-   - php: 8.0
-   - php: nightly
-
-  allow_failures:
-    - php: nightly
 
 cache:
   directories:
@@ -41,28 +20,20 @@ cache:
     - $HOME/.cache/composer/files
 
 install:
- # Speed up build time by disabling Xdebug unless actually needed.
+ # Speed up build time by disabling Xdebug.
  # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
  # https://twitter.com/kelunik/status/954242454676475904
- - if [ "$TEST_COVERAGE" != '1' ]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
+ - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
  # Setup the test server
- - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then phpenv local $( phpenv versions | grep 5.6 | tail -1 ); fi
- - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then travis_retry composer remove --dev --no-update phpunit/phpunit; fi
- - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then export PHPUNIT_BIN="phpunit";
-   else export PHPUNIT_BIN="$(pwd)/vendor/bin/phpunit";
-   fi
+ - phpenv local $( phpenv versions | grep 5.6 | tail -1 )
  # The PHPCS and lint dependencies require PHP 5.3, so would block install on PHP < 5.3.
  # As they are only needed for code sniffing, remove them.
- - travis_retry composer remove --dev --no-update squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter
- - |
-   if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
-    travis_retry composer install --no-interaction --ignore-platform-reqs
-   else
-    travis_retry composer install --no-interaction
-   fi
+ # Also remove PHPUnit as we'll be using the Phar provided by Travis.
+ - travis_retry composer remove --dev --no-update phpunit/phpunit squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter
+ - travis_retry composer install --no-interaction
  - TESTPHPBIN=$(phpenv which php)
- - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then phpenv local --unset; fi
+ - phpenv local --unset
 
  # Setup the proxy
  - pip install --user mitmproxy==0.18.2
@@ -82,7 +53,7 @@ before_script:
  - curl -s -I http://requests-php-tests.herokuapp.com/ > /dev/null
 
  # Environment checks
- - $PHPUNIT_BIN --version
+ - phpunit --version
 
 script:
  # Lint PHP files against parse errors for PHP 5.2 - 5.4.
@@ -97,10 +68,8 @@ script:
 
  # Run the unit tests.
  - |
-   if [ "$TEST_COVERAGE" == '1' ]; then
-     $PHPUNIT_BIN --coverage-clover clover.xml;
    # PHPUnit 4.x does not yet support the `no-coverage` flag.
-   elif [ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]; then
+   if [ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]; then
      $PHPUNIT_BIN;
    else
      $PHPUNIT_BIN --no-coverage;
@@ -109,4 +78,3 @@ script:
 after_script:
  - tests/utils/proxy/stop.sh
  - PATH=$PATH vendor/bin/stop.sh
- - test $TEST_COVERAGE && bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ install:
  - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then export PHPUNIT_BIN="phpunit";
    else export PHPUNIT_BIN="$(pwd)/vendor/bin/phpunit";
    fi
- # The PHPCS dependencies require PHP 5.4, so would block istall on PHP < 5.4.
+ # The PHPCS and lint dependencies require PHP 5.3, so would block install on PHP < 5.3.
  # As they are only needed for code sniffing, remove them.
- - travis_retry composer remove --dev --no-update squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
+ - travis_retry composer remove --dev --no-update squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer php-parallel-lint/php-parallel-lint php-parallel-lint/php-console-highlighter
  - |
    if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer install --no-interaction --ignore-platform-reqs
@@ -85,13 +85,13 @@ before_script:
  - $PHPUNIT_BIN --version
 
 script:
- # Lint PHP files against parse errors.
+ # Lint PHP files against parse errors for PHP 5.2 - 5.4.
  - |
    if [ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]; then
      if find $(pwd)/ -path $(pwd)/vendor -prune -o -path $(pwd)/ examples/cookie_jar.php -prune -o -path $(pwd)/tests/phpunit6-compat.php -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
    elif [ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]; then
      if find $(pwd)/ -path $(pwd)/vendor -prune -o -path $(pwd)/ examples/cookie_jar.php -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
-   else
+   elif [ ${TRAVIS_PHP_VERSION:0:3} == "5.4" ]; then
      if find $(pwd)/ -path $(pwd)/vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
    fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,13 @@
 dist: xenial
 language: php
 
-stages:
-  - sniff
-  - test
-
 env:
   - COMPOSER_PHPUNIT=true
 
 jobs:
   fast_finish: true
   include:
-   - stage: sniff
-     php: 7.4
-     install:
-       - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-       - travis_retry composer install --no-interaction
-     before_script: skip
-     script:
-       # Check the code against the coding standards.
-       - composer checkcs
-     after_script: skip
-
-   - stage: test
-     php: 5.2
+   - php: 5.2
      dist: precise
      env: COMPOSER_PHPUNIT=false
    - php: 5.3
@@ -68,12 +52,9 @@ install:
  - if [ "$COMPOSER_PHPUNIT" == 'false' ]; then export PHPUNIT_BIN="phpunit";
    else export PHPUNIT_BIN="$(pwd)/vendor/bin/phpunit";
    fi
- - |
-   if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" ]]; then
-    # The PHPCS dependencies require PHP 5.4, so would block istall on PHP < 5.4.
-    # As they are only needed in the sniff stage, remove them.
-    travis_retry composer remove --dev --no-update squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
-   fi
+ # The PHPCS dependencies require PHP 5.4, so would block istall on PHP < 5.4.
+ # As they are only needed for code sniffing, remove them.
+ - travis_retry composer remove --dev --no-update squizlabs/php_codesniffer phpcompatibility/php-compatibility wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
  - |
    if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Requests for PHP
 ================
 
+[![CS](https://github.com/WordPress/Requests/actions/workflows/cs.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/cs.yml)
 [![Build Status](https://travis-ci.org/WordPress/Requests.svg?branch=master)](https://travis-ci.org/WordPress/Requests)
 [![codecov.io](http://codecov.io/github/WordPress/Requests/coverage.svg?branch=master)](http://codecov.io/github/WordPress/Requests?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Requests for PHP
 ================
 
 [![CS](https://github.com/WordPress/Requests/actions/workflows/cs.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/cs.yml)
+[![Lint](https://github.com/WordPress/Requests/actions/workflows/lint.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/lint.yml)
 [![Build Status](https://travis-ci.org/WordPress/Requests.svg?branch=master)](https://travis-ci.org/WordPress/Requests)
 [![codecov.io](http://codecov.io/github/WordPress/Requests/coverage.svg?branch=master)](http://codecov.io/github/WordPress/Requests?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Requests for PHP
 
 [![CS](https://github.com/WordPress/Requests/actions/workflows/cs.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/cs.yml)
 [![Lint](https://github.com/WordPress/Requests/actions/workflows/lint.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/lint.yml)
-[![Build Status](https://travis-ci.org/WordPress/Requests.svg?branch=master)](https://travis-ci.org/WordPress/Requests)
+[![Test](https://github.com/WordPress/Requests/actions/workflows/test.yml/badge.svg)](https://github.com/WordPress/Requests/actions/workflows/test.yml)
+[![CI PHP 5.2-5.4](https://travis-ci.org/WordPress/Requests.svg?branch=master)](https://travis-ci.org/WordPress/Requests)
 [![codecov.io](http://codecov.io/github/WordPress/Requests/coverage.svg?branch=master)](http://codecov.io/github/WordPress/Requests?branch=master)
 
 Requests is a HTTP library written in PHP, for human beings. It is roughly

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,18 @@
 		"squizlabs/php_codesniffer": "^3.5",
 		"phpcompatibility/php-compatibility": "^9.0",
 		"wp-coding-standards/wpcs": "^2.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+		"php-parallel-lint/php-parallel-lint": "^1.3",
+		"php-parallel-lint/php-console-highlighter": "^0.5.0"
 	},
 	"type": "library",
 	"autoload": {
 		"psr-0": {"Requests": "library/"}
 	},
 	"scripts" : {
+		"lint": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+		],
 		"checkcs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
 		],

--- a/tests/Proxy/HTTP.php
+++ b/tests/Proxy/HTTP.php
@@ -119,7 +119,7 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 	public function testConnectWithInvalidAuth($transport) {
 		$this->checkProxyAvailable('auth');
 
-		$options  = array(
+		$options = array(
 			'proxy'     => array(
 				REQUESTS_HTTP_PROXY_AUTH,
 				REQUESTS_HTTP_PROXY_AUTH_USER . '!',
@@ -127,6 +127,17 @@ class RequestsTest_Proxy_HTTP extends PHPUnit_Framework_TestCase {
 			),
 			'transport' => $transport,
 		);
+
+		if ($transport === 'Requests_Transport_fsockopen') {
+			// @TODO fsockopen connection times out on invalid auth instead of returning 407.
+			if (method_exists($this, 'expectException')) {
+				$this->expectException('Requests_Exception');
+				$this->expectExceptionMessage('fsocket timed out');
+			} else {
+				$this->setExpectedException('Requests_Exception', 'fsocket timed out');
+			}
+		}
+
 		$response = Requests::get(httpbin('/get'), array(), $options);
 		$this->assertSame(407, $response->status_code);
 	}

--- a/tests/utils/proxy/start.sh
+++ b/tests/utils/proxy/start.sh
@@ -6,8 +6,14 @@ PORT=${PORT:-9000}
 PROXYBIN=${PROXYBIN:-"$(which mitmdump)"}
 ARGS="-s '$PROXYDIR/proxy.py' -p $PORT"
 if [[ ! -z "$AUTH" ]]; then
-	ARGS="$ARGS --singleuser=$AUTH"
+	ARGS="$ARGS --proxyauth $AUTH"
 fi
-PIDFILE="$PROXYDIR/proxy.pid"
+PIDFILE="$PROXYDIR/proxy-$PORT.pid"
 
-start-stop-daemon --start --background --pidfile $PIDFILE --make-pidfile --exec $PROXYBIN -- $ARGS
+set -x
+
+start-stop-daemon --verbose --start --background --pidfile $PIDFILE --make-pidfile --exec $PROXYBIN -- $ARGS
+
+ps -p $(cat $PIDFILE) -u
+sleep 2
+ps -p $(cat $PIDFILE) -u

--- a/tests/utils/proxy/stop.sh
+++ b/tests/utils/proxy/stop.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 PROXYDIR="$PWD/$(dirname $0)"
+PORT=${PORT:-9000}
 
-PIDFILE="$PROXYDIR/proxy.pid"
+PIDFILE="$PROXYDIR/proxy-$PORT.pid"
 
-start-stop-daemon --stop --pidfile $PIDFILE --make-pidfile && rm $PROXYDIR/proxy.pid
+set -x
+
+start-stop-daemon --verbose --stop --pidfile $PIDFILE --remove-pidfile


### PR DESCRIPTION
Depends on: PRs #458 (and by extension PR #457) and #464.
Those PRs will need to be merged before this PR can become mergable.

Supersedes: PRs #447 and #461

Closes #447
Closes #461


## TL;DR

This PR moves the CI checks for PHP 5.5 - current to GH Actions, while leaving the CI checks against PHP 5.2 - 5.4 to be run via Travis. This allows for this move to be done _now_ while PHP 5.2 - 5.4 are still supported and will still safeguard (via Travis) that the code is still compatible with PHP 5.2 - 5.4.

This PR incorporates the work previously done by @schlessera in #447 and builds on that.


**Background of why the PHP 5.2-5.4 builds won't be able to move to GH Actions:**
The code of the test-server used during the running of the unit tests requires PHP 5.5 minimum due to the use of `yield`.

On Travis, it is possible to use PHP 5.6 to start and run the test server, while running the tests themselves on a lower PHP version within the same workflow.

On GH Actions, while it is possible to switch PHP versions during a workflow, this switch will affect all code, so the test server can not run on a different PHP version than the tests, effectively blocking PHP 5.2-5.4.


## Commit details

### CI: switch to GitHub Actions - step 1: sniff/CS workflow

This commit:
* Adds a GH Actions workflow for the CI checks which were previously run on Travis in the `sniff` stage.
* Removes that part of the `.travis.yml` configuration.
* Adds a "Build Status" badge in the Readme to use the results from this particular GH Actions runs.

### CI: switch to GitHub Actions - step 2: lint workflow

This commit:
* Add a new dependency on the PHP Parallel Lint package which will be used for linting on PHP >= 5.4.
    The PHP Parallel Lint package, in combination with the PHP Console Highlighter provides the following advantages in comparison with "plain" PHP linting:
    - Higher speed due to the parallel processes.
    - Improved usability by providing color coded syntax highlighting of found errors on the command-line.
    - Integration with the `cs2pr` tool, allowing for the results of the lint command to be shown in-line in PRs.
* Adds a Composer `lint` script for easy access to the tool for devs, while making sure the correct command line parameters will be used.
* Adds a GH Actions workflow for linting the code on the high/low minors of each PHP major version.
    Note: this workflow will only run on PHP >= 5.4. Linting against PHP 5.2 and 5.3 will remain in Travis for now.
* Removes the part of the `.travis.yml` configuration which has now been replaced.
* Adds a "Build Status" badge in the Readme to use the results from this particular GH Actions runs.

### Fix proxy scripts to work with newest mitmproxy release

### Add edge case TODO for fsockopen invalid auth test

### CI: switch to GitHub Actions - step 3: test and coverage stage

This commit:
* Adds a GH Actions workflow for running the unit tests against PHP 5.5 - current.
    Note:
    - This workflow will run for all pull requests and for merges to master, but not for other push events.
    - Code coverage will be checked for the highest and lowest PHP version so the results can be combined to cover any polyfills and work-arounds.
        Includes adjusting the codecov configuration to expect 2 reports for each build.
    - The PHP 8.1 (nightly) job is "allowed to fail" (`experimental` = true). If it does fail, the build status will unfortunately show as "failed", even though all non-experimental jobs have succeeded.
         This is a known issue in GHA: actions/toolkit#399
    - For PHP 5.2-5.4, the tests will still be run via Travis as the test server setup is incompatible with PHP < 5.5 and using multiple PHP versions in a workflow run does work on Travis, but doesn't work the same on GH Actions.
* Strips down the `.travis.yml` configuration to the bare minimum to run the tests against PHP 5.2 - 5.4.
* Adds a "Build Status" badge in the Readme to use the results from this particular GH Actions runs.

Note: for the time being, the tests will not be run against PHP 8.1/nightly as PHPUnit 7 is incompatible, meaning that that build would _always_ fail.
Once the version constraints for PHPUnit have been widened (see PR #446), the build against PHP nightly should be enabled.




### CI: switch to GitHub Actions - step 4: introduce a quick test workflow

Previous, the Travis all-in-one workflow would run on every push and every PR, making for a lot of redundancy in the builds.

GH Actions allows to run workflows far more selectively.

The "Test" workflow has been configured to run against all supported PHP versions for pushes (merges) to `master`, as well as for pull requests.

This commit introduces a "Quick test" workflow, which is basically the same as the full "Test" workflow (without code coverage checking).
This workflow will only run the tests against a few select PHP versions on `push` events, when the push is not to the `master` branch.

This allows for people working on feature branches to still get a quick impression of whether their branch is ready to be pulled, while conserving resources by not running the full build until the branch has been pulled.

