### PR TITLE
Manage "Expect" header with cURL transport

### DIFF
--- a/tests/Transport/cURL.php
+++ b/tests/Transport/cURL.php
@@ -36,4 +36,104 @@ class RequestsTest_Transport_cURL extends RequestsTest_Transport_Base {
 	public function testBadDomain() {
 		parent::testBadDomain();
 	}
+
+	/**
+	 * @small
+	 */
+	public function testDoesntOverwriteExpectHeaderIfManuallySet() {
+		$headers = array(
+			'Expect' => 'foo',
+		);
+		$request = Requests::post(httpbin('/post'), $headers, array(), $this->getOptions());
+
+		$result = json_decode($request->body, true);
+
+		$this->assertSame($headers['Expect'], $result['headers']['Expect']);
+	}
+
+	/**
+	 * @small
+	 */
+	public function testDoesntSetExpectHeaderIfBodyExactly1MbButProtocolIsnt11() {
+		$options = array(
+			'protocol_version' => 1.0,
+		);
+		$request = Requests::post(httpbin('/post'), array(), str_repeat('x', 1048576), $this->getOptions($options));
+
+		$result = json_decode($request->body, true);
+
+		$this->assertFalse(isset($result['headers']['Expect']));
+	}
+
+	/**
+	 * @small
+	 */
+	public function testSetsEmptyExpectHeaderWithDefaultSettings() {
+		$request = Requests::post(httpbin('/post'), array(), array(), $this->getOptions());
+
+		$result = json_decode($request->body, true);
+
+		$this->assertFalse(isset($result['headers']['Expect']));
+	}
+
+	/**
+	 * @small
+	 */
+	public function testSetsEmptyExpectHeaderIfBodyIsANestedArrayLessThan1Mb() {
+		$data    = array(
+			str_repeat('x', 148576),
+			array(
+				str_repeat('x', 548576),
+			),
+		);
+		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+
+		$result = json_decode($request->body, true);
+
+		$this->assertFalse(isset($result['headers']['Expect']));
+	}
+
+	public function testSetsExpectHeaderIfBodyIsExactlyA1MbString() {
+		$request = Requests::post(httpbin('/post'), array(), str_repeat('x', 1048576), $this->getOptions());
+
+		$result = json_decode($request->body, true);
+
+		$this->assertSame('100-Continue', $result['headers']['Expect']);
+	}
+
+	public function testSetsExpectHeaderIfBodyIsANestedArrayGreaterThan1Mb() {
+		$data    = array(
+			str_repeat('x', 148576),
+			array(
+				str_repeat('x', 548576),
+				array(
+					str_repeat('x', 648576),
+				),
+			),
+		);
+		$request = Requests::post(httpbin('/post'), array(), $data, $this->getOptions());
+
+		$result = json_decode($request->body, true);
+
+		$this->assertSame('100-Continue', $result['headers']['Expect']);
+	}
+
+	public function testSetsExpectHeaderIfBodyExactly1Mb() {
+		$request = Requests::post(httpbin('/post'), array(), str_repeat('x', 1048576), $this->getOptions());
+
+		$result = json_decode($request->body, true);
+
+		$this->assertSame('100-Continue', $result['headers']['Expect']);
+	}
+
+	/**
+	 * @small
+	 */
+	public function testSetsEmptyExpectHeaderIfBodySmallerThan1Mb() {
+		$request = Requests::post(httpbin('/post'), array(), str_repeat('x', 1048575), $this->getOptions());
+
+		$result = json_decode($request->body, true);
+
+		$this->assertFalse(isset($result['headers']['Expect']));
+	}
 }


### PR DESCRIPTION
Fixes #453 

This PR was originally authored by @carlalexander, and I only recreate it here because I messed up the original PR found at #454 .