### PR TITLE
Add misc. files to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,5 @@ tests/ export-ignore
 .gitattributes export-ignore
 .phpcs.xml.dist export-ignore
 .travis.yml export-ignore
-CHANGELOG.md export-ignore
 package.xml.tpl export-ignore
 phpunit.xml.dist export-ignore
-README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,9 +3,13 @@ bin/ export-ignore
 docs/ export-ignore
 examples/ export-ignore
 tests/ export-ignore
+.codecov.yml export-ignore
 .coveralls.yml export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
 .phpcs.xml.dist export-ignore
 .travis.yml export-ignore
+CHANGELOG.md export-ignore
 package.xml.tpl export-ignore
+phpunit.xml.dist export-ignore
+README.md export-ignore


### PR DESCRIPTION
There are a handful of repository specific config and info files still downloaded with a fresh `composer install` of this package, these are now ignored