### PR TITLE
Requests::Version: update version number

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,9 +4,8 @@ docs/ export-ignore
 examples/ export-ignore
 tests/ export-ignore
 .codecov.yml export-ignore
-.coveralls.yml export-ignore
-.gitignore export-ignore
 .gitattributes export-ignore
+.gitignore export-ignore
 .phpcs.xml.dist export-ignore
 .travis.yml export-ignore
 package.xml.tpl export-ignore

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -88,7 +88,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.7';
+	const VERSION = '1.8.1';
 
 	/**
 	 * Registered transport classes


### PR DESCRIPTION
Oops.. looks like we forgot something for the release. Only just noticed it when I checked the file diff for the WP Core patch.

As the version constant is generally used to verify the version for using certain features of a package, does this warrant a `1.8.1` release ?

And if so, should I update the version number to `1.8.1` in this PR ?