### PR TITLE
Update to WordPressCS 3.0.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -71,12 +71,6 @@
 		<!-- Replaced by the Squiz version of the sniff which doesn't enforce whitespace around array index keys. -->
 		<exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
 
-		<!-- Disabled as the preference for this repo is no spaces on the inside of parentheses.
-			 Once WPCS 3.0.0 comes out, the opposite can be enforced via the
-			 NormalizedArrays.Arrays.ArrayBraceSpacing sniff from PHPCSExtra. -->
-		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceAfterArrayOpener"/>
-		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceBeforeArrayCloser"/>
-
 		<!-- Let spacing before a cast be determined by the operator/parentheses whitespace rule
 			 of the preceding character. -->
 		<exclude name="WordPress.WhiteSpace.CastStructureSpacing"/>
@@ -86,7 +80,7 @@
 			 ========================================================================== -->
 		<exclude name="WordPress.PHP.YodaConditions"/>
 		<!-- A while loop is the only valid control structure where an assignment can be justified. -->
-		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
+		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
 
 		<!-- ==========================================================================
 			 Miscellaneous other exclusions.
@@ -96,7 +90,7 @@
 		<exclude name="WordPress.Files.FileName"/>
 
 		<!-- WPCS demands long arrays. We'll be using short arrays from now on. -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
 
 		<!-- Ignore WP specific sniffs as Requests is also used outside of a WP context. -->
 		<exclude name="WordPress.WP"/>
@@ -130,6 +124,12 @@
 	<rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing">
 		<properties>
 			<property name="spacing" value="0"/>
+		</properties>
+	</rule>
+
+	<rule ref="NormalizedArrays.Arrays.ArrayBraceSpacing">
+		<properties>
+			<property name="spacesSingleLine" value="0"/>
 		</properties>
 	</rule>
 
@@ -173,7 +173,7 @@
 	<!-- Allow error silencing only for a select group of functions. -->
 	<rule ref="WordPress.PHP.NoSilencedErrors">
 		<properties>
-			<property name="custom_whitelist" type="array">
+			<property name="customAllowedFunctionsList" type="array">
 				<element value="gzdecode"/>
 				<element value="gzinflate"/>
 				<element value="gzuncompress"/>

--- a/composer.json
+++ b/composer.json
@@ -41,14 +41,12 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "php-parallel-lint/php-parallel-lint": "^1.3.2",
     "phpcompatibility/php-compatibility": "^9.0",
     "requests/test-server": "dev-main",
     "roave/security-advisories": "dev-latest",
-    "squizlabs/php_codesniffer": "^3.7.1",
-    "wp-coding-standards/wpcs": "^2.0",
+    "wp-coding-standards/wpcs": "^3.0",
     "yoast/phpunit-polyfills": "^2.0.0"
   },
   "suggest": {

--- a/library/Requests.php
+++ b/library/Requests.php
@@ -53,6 +53,8 @@ class Requests extends WpOrg\Requests\Requests {
 	 *
 	 * @codeCoverageIgnore
 	 *
+	 * @phpcs:disable Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- Deprecated, so not relevant to change.
+	 *
 	 * @param string $class Class name to load
 	 */
 	public static function autoloader($class) {

--- a/src/Session.php
+++ b/src/Session.php
@@ -227,7 +227,13 @@ class Session {
 	 * @throws \WpOrg\Requests\Exception On invalid URLs (`nonhttp`)
 	 */
 	public function request($url, $headers = [], $data = [], $type = Requests::GET, $options = []) {
-		$request = $this->merge_request(compact('url', 'headers', 'data', 'options'));
+		$request = [
+			'url'     => $url,
+			'headers' => $headers,
+			'data'    => $data,
+			'options' => $options,
+		];
+		$request = $this->merge_request($request);
 
 		return Requests::request($request['url'], $request['headers'], $request['data'], $type, $request['options']);
 	}

--- a/tests/Autoload/AutoloadTest.php
+++ b/tests/Autoload/AutoloadTest.php
@@ -67,7 +67,7 @@ final class AutoloadTest extends TestCase {
 	public function testAutoloadOfOldRequestsClassDoesNotThrowAFatalForFinalClass() {
 		define('REQUESTS_SILENCE_PSR0_DEPRECATIONS', true);
 
-		$this->assertInstanceOf(FilteredIterator::class, new Requests_utility_filteredIterator([], static function() {}));
+		$this->assertInstanceOf(FilteredIterator::class, new Requests_utility_filteredIterator([], static function () {}));
 	}
 
 	/**

--- a/tests/Cookie/ConstructorTest.php
+++ b/tests/Cookie/ConstructorTest.php
@@ -356,7 +356,7 @@ final class ConstructorTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	private function arrayUnshiftAssoc($base_array, $key, $value ) {
+	private function arrayUnshiftAssoc($base_array, $key, $value) {
 		$base_array       = array_reverse($base_array, true);
 		$base_array[$key] = $value;
 		return array_reverse($base_array, true);

--- a/tests/Hooks/DispatchTest.php
+++ b/tests/Hooks/DispatchTest.php
@@ -120,48 +120,48 @@ class DispatchTest extends TestCase {
 		// Register multiple callbacks for the same hook with a variation of priorities.
 		$this->hooks->register(
 			'hook_a',
-			static function(&$text) {
+			static function (&$text) {
 				$text .= "no prio 0\n";
 			}
 		);
 		$this->hooks->register(
 			'hook_a',
-			static function(&$text) {
+			static function (&$text) {
 				$text .= "prio 10-1\n";
 			},
 			10
 		);
 		$this->hooks->register(
 			'hook_a',
-			static function(&$text) {
+			static function (&$text) {
 				$text .= "prio -3\n";
 			},
 			-3
 		);
 		$this->hooks->register(
 			'hook_a',
-			static function(&$text) {
+			static function (&$text) {
 				$text .= "prio 5\n";
 			},
 			5
 		);
 		$this->hooks->register(
 			'hook_a',
-			static function(&$text) {
+			static function (&$text) {
 				$text .= "prio 2-1\n";
 			},
 			2
 		);
 		$this->hooks->register(
 			'hook_a',
-			static function(&$text) {
+			static function (&$text) {
 				$text .= "prio 2-2\n";
 			},
 			2
 		);
 		$this->hooks->register(
 			'hook_a',
-			static function(&$text) {
+			static function (&$text) {
 				$text .= "prio 10-2\n";
 			},
 			10

--- a/tests/Hooks/RegisterTest.php
+++ b/tests/Hooks/RegisterTest.php
@@ -183,7 +183,7 @@ class RegisterTest extends TestCase {
 	public function testRegisterClosureCallback() {
 		$this->hooks->register(
 			'hookname',
-			static function($param) {
+			static function() {
 				return true;
 			}
 		);

--- a/tests/Hooks/RegisterTest.php
+++ b/tests/Hooks/RegisterTest.php
@@ -183,7 +183,7 @@ class RegisterTest extends TestCase {
 	public function testRegisterClosureCallback() {
 		$this->hooks->register(
 			'hookname',
-			static function() {
+			static function () {
 				return true;
 			}
 		);


### PR DESCRIPTION
### Composer: update to WordPressCS 3.0.0

Composer:
* No need for requiring the Composer PHPCS plugin anymore as it now comes automatically with WPCS and removing the requirement allows WPCS to manage the supported versions, preventing conflicts (and will update us to the 1.0.0 version).
* As the minimum supported version of PHPCS for WPCS is now above 3.7.1, we don't need the explicit require for PHPCS anymore either.

PHPCS ruleset:
* Various tweaks to the sniff and property names as per the changes in WPCS 3.0.0.

Refs:
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.0
* https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-ruleset-maintainers

### WordPressCS 3.0.0: add ignore annotation

... for a parameter using a reserved keyword for its name, which is discouraged.

This method is deprecated, so changing this is irrelevant.

### Session: remove use of compact()

... and make the build up of the `$request` explicit.

This removes a warning about a (not) "unused parameter".

### RegisterTest: remove unused parameter

### Various minor CS fixes

### GH Actions: run CS check against PHP "latest"

... as WordPressCS will not throw deprecations anymore.