### PR TITLE
Composer: bump minimum versions for some dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,12 +42,12 @@
   },
   "require-dev": {
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
-    "php-parallel-lint/php-parallel-lint": "^1.3.2",
-    "phpcompatibility/php-compatibility": "^9.0",
+    "php-parallel-lint/php-parallel-lint": "^1.4.0",
+    "phpcompatibility/php-compatibility": "^9.3.5",
     "requests/test-server": "dev-main",
     "roave/security-advisories": "dev-latest",
-    "wp-coding-standards/wpcs": "^3.0",
-    "yoast/phpunit-polyfills": "^2.0.0"
+    "wp-coding-standards/wpcs": "^3.1",
+    "yoast/phpunit-polyfills": "^2.0.1"
   },
   "suggest": {
     "ext-curl": "For improved performance",


### PR DESCRIPTION
Each of these dependencies has a minimum PHP version which aligns with the minimum PHP version of this package, so these can safely be "bumped" to enforce using the latest versions of these dependencies (which is what would be used in CI anyway).
