### PR TITLE
GH Actions: add shellcheck job + allow scripts to pass the new check

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The linter can be run locally using `composer lint`.
 
 [PHP Parallel Lint]: https://github.com/php-parallel-lint/PHP-Parallel-Lint
 
-## Coding Style
+## PHP Coding Style
 
 Please follow the existing coding style and best practices.
 This project uses [PHP_CodeSniffer][] to detect coding standard violations and apply automated fixes (whenever possible).
@@ -71,6 +71,19 @@ This project uses [PHP_CodeSniffer][] to detect coding standard violations and a
 * Any automatically applicable fixes can be applied by running `composer fixcs`.
 
 [PHP_CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer
+
+## Shell script QA & Coding Style
+
+All shell scripts used in this project are, and should be, located in the `/scripts` directory.
+
+Please follow the existing coding style and best practices.
+This project uses [ShellCheck][] to detect violations.
+
+* Shellcheck can be [installed on all platforms][shellcheck-install]
+* All files can be checked for coding standard violations by running `shellcheck`.
+
+[ShellCheck]:         https://github.com/koalaman/shellcheck
+[shellcheck-install]: https://github.com/koalaman/shellcheck#user-content-installing
 
 ## Unit Tests
 

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -67,3 +67,21 @@ jobs:
       - name: Show PHPCS results in PR
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml
+
+  shellcheck: #----------------------------------------------------------------------
+    name: 'ShellCheck'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up problem matcher
+        uses: lumaxis/shellcheck-problem-matchers@v2
+        with:
+          format: gcc
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          format: gcc

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,9 @@
+shell=bash
+color=always
+
+external-sources=false
+source-path=/scripts
+source-path=/scripts/proxy
+
+# Turn on all checks.
+enable=all

--- a/scripts/proxy/start.sh
+++ b/scripts/proxy/start.sh
@@ -4,15 +4,16 @@ PROXYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PORT=${PORT:-9000}
 
 PROXYBIN=${PROXYBIN:-"$(which mitmdump)"}
-ARGS="-s '$PROXYDIR/proxy.py' -p $PORT"
+
+ARGS=(-s "$PROXYDIR/proxy.py" -p "$PORT")
 if [[ -n "$AUTH" ]]; then
-	ARGS="$ARGS --proxyauth $AUTH"
+	ARGS+=("--proxyauth" "$AUTH")
 fi
 PIDFILE="$PROXYDIR/proxy-$PORT.pid"
 
 set -x
 
-start-stop-daemon --verbose --start --background --pidfile "$PIDFILE" --make-pidfile --exec "$PROXYBIN" -- $ARGS
+start-stop-daemon --verbose --start --background --pidfile "$PIDFILE" --make-pidfile --exec "$PROXYBIN" -- "${ARGS[@]}"
 
 ps -p "$(cat "$PIDFILE")" u
 sleep 2

--- a/scripts/proxy/start.sh
+++ b/scripts/proxy/start.sh
@@ -5,15 +5,15 @@ PORT=${PORT:-9000}
 
 PROXYBIN=${PROXYBIN:-"$(which mitmdump)"}
 ARGS="-s '$PROXYDIR/proxy.py' -p $PORT"
-if [[ ! -z "$AUTH" ]]; then
+if [[ -n "$AUTH" ]]; then
 	ARGS="$ARGS --proxyauth $AUTH"
 fi
 PIDFILE="$PROXYDIR/proxy-$PORT.pid"
 
 set -x
 
-start-stop-daemon --verbose --start --background --pidfile $PIDFILE --make-pidfile --exec $PROXYBIN -- $ARGS
+start-stop-daemon --verbose --start --background --pidfile "$PIDFILE" --make-pidfile --exec "$PROXYBIN" -- $ARGS
 
-ps -p $(cat $PIDFILE) u
+ps -p "$(cat "$PIDFILE")" u
 sleep 2
-ps -p $(cat $PIDFILE) u
+ps -p "$(cat "$PIDFILE")" u

--- a/scripts/proxy/stop.sh
+++ b/scripts/proxy/stop.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-PROXYDIR="$PWD/$(dirname $0)"
+PROXYDIR="$PWD/$(dirname "$0")"
 PORT=${PORT:-9000}
 
 PIDFILE="$PROXYDIR/proxy-$PORT.pid"
 
 set -x
 
-start-stop-daemon --verbose --stop --pidfile $PIDFILE --remove-pidfile
+start-stop-daemon --verbose --stop --pidfile "$PIDFILE" --remove-pidfile


### PR DESCRIPTION
## Detailed Description

### GH Actions: add shellcheck job

Shellcheck is a static analysis tool for shell scripts, which can help find common mistakes, simplifications and point out best practices.

This commit adds a new GH Actions job to run shellcheck on all shell scripts in this repo.
At this moment, that means it will run over the `tests/utils/proxy` start/stop scripts, but more scripts are expected to be added in the near future.

I've researched the available action runners and found the `ludeeus/action-shellcheck` one to be the most popular as well as suitable for our needs.
Additionally, the `lumaxis/shellcheck-problem-matchers` will allow for showing any issues found inline in the GH code view via annotations.

Refs:
* https://www.shellcheck.net/
* https://github.com/koalaman/shellcheck/wiki/Integration
* https://github.com/ludeeus/action-shellcheck
* https://github.com/lumaxis/shellcheck-problem-matchers

### [INCOMPLETE] Shell scripts: various tweaks

Various tweaks to allow the scripts to pass the shellcheck checks.

:warning: At this time, the scripts do NOT (yet) pass `shellcheck` - this is mostly due to quoting `$ARGS` in the `start-stop-daemon` command breaking the test runs. For that reason, this PR is being opened as draft.