### PR TITLE
Add QUERY HTTP method to the list of allowed methods

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,7 +116,7 @@ $response = \WpOrg\Requests\Requests::query('https://httpbin.org/anything', arra
 As with `POST`, you can pass a string instead of an array to send raw data, and
 you'll probably want to set the `Content-Type` header to match.
 
-[rfc10008]: https://www.rfc-editor.org/rfc/rfc10008
+[rfc10008]: https://tools.ietf.org/html/rfc10008
 
 
 Status Codes

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,6 +102,23 @@ on the internal execution path, so it's recommended to set this explicitly if
 you need to.
 
 
+Make a QUERY Request
+--------------------
+The [`QUERY`][rfc10008] method (RFC 10008) is like `GET`, but sends its data in
+the request body instead of the URL query string. This lets you send large or
+complex queries while keeping the safe and idempotent semantics of `GET`:
+
+```php
+$data = array('key1' => 'value1', 'key2' => 'value2');
+$response = \WpOrg\Requests\Requests::query('https://httpbin.org/anything', array(), $data);
+```
+
+As with `POST`, you can pass a string instead of an array to send raw data, and
+you'll probably want to set the `Content-Type` header to match.
+
+[rfc10008]: https://www.rfc-editor.org/rfc/rfc10008
+
+
 Status Codes
 ------------
 The Response object also gives you access to the status code:

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -98,6 +98,14 @@ class Requests {
 	const PATCH = 'PATCH';
 
 	/**
+	 * QUERY method
+	 *
+	 * @link https://www.rfc-editor.org/rfc/rfc10008
+	 * @var string
+	 */
+	const QUERY = 'QUERY';
+
+	/**
 	 * Default size of buffer size to read streams
 	 *
 	 * @var int
@@ -365,6 +373,18 @@ class Requests {
 	public static function patch($url, $headers, $data = [], $options = []) {
 		return self::request($url, $headers, $data, self::PATCH, $options);
 	}
+
+	/**
+	 * Send a QUERY request
+	 *
+	 * Note: Unlike {@see \WpOrg\Requests\Requests::get()}, the `$data` is sent in the
+	 * request body (like POST), not appended to the URL as a query string.
+	 *
+	 * @link https://www.rfc-editor.org/rfc/rfc10008 RFC 10008
+	 */
+	public static function query($url, $headers = [], $data = [], $options = []) {
+		return self::request($url, $headers, $data, self::QUERY, $options);
+	}
 	/**#@-*/
 
 	/**
@@ -416,7 +436,7 @@ class Requests {
 	 *    (bool, default: true)
 	 * - `data_format`: How should we send the `$data` parameter?
 	 *    (string, one of 'query' or 'body', default: 'query' for
-	 *    HEAD/GET/DELETE, 'body' for POST/PUT/OPTIONS/PATCH)
+	 *    HEAD/GET/DELETE, 'body' for POST/PUT/OPTIONS/PATCH/QUERY)
 	 *
 	 * @param string|\Stringable $url     URL to request
 	 * @param array              $headers Extra headers to send with the request

--- a/src/Requests.php
+++ b/src/Requests.php
@@ -100,7 +100,7 @@ class Requests {
 	/**
 	 * QUERY method
 	 *
-	 * @link https://www.rfc-editor.org/rfc/rfc10008
+	 * @link https://tools.ietf.org/html/rfc10008
 	 * @var string
 	 */
 	const QUERY = 'QUERY';
@@ -380,7 +380,7 @@ class Requests {
 	 * Note: Unlike {@see \WpOrg\Requests\Requests::get()}, the `$data` is sent in the
 	 * request body (like POST), not appended to the URL as a query string.
 	 *
-	 * @link https://www.rfc-editor.org/rfc/rfc10008 RFC 10008
+	 * @link https://tools.ietf.org/html/rfc10008
 	 */
 	public static function query($url, $headers = [], $data = [], $options = []) {
 		return self::request($url, $headers, $data, self::QUERY, $options);

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -570,6 +570,23 @@ abstract class BaseTestCase extends TestCase {
 		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
 	}
 
+	public function testQUERY() {
+		$request = Requests::query($this->httpbin('/query'), [], [], $this->getOptions());
+		$this->assertSame(200, $request->status_code);
+	}
+
+	public function testQUERYWithData() {
+		$data    = [
+			'test'  => 'true',
+			'test2' => 'test',
+		];
+		$request = Requests::query($this->httpbin('/query'), [], $data, $this->getOptions());
+		$this->assertSame(200, $request->status_code);
+
+		$result = json_decode($request->body, true);
+		$this->assertSame(['test' => 'true', 'test2' => 'test'], $result['form']);
+	}
+
 	public function testRedirects() {
 		$request = Requests::get($this->httpbin('/redirect/6'), [], $this->getOptions());
 		$this->assertSame(200, $request->status_code);


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [ ] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Code quality improvement

## Context

New HTTP method has been approved (https://www.rfc-editor.org/info/rfc10008/), this PR aims to add the support for it in the Requests lib.

## Detailed Description

PR for issue https://github.com/WordPress/Requests/issues/1074. 

The PR adds new constant for the new HTTP method and the helper method that accompanies it.

I have also made a PR for the CI server for tests: https://github.com/RequestsPHP/test-server/pull/13.

In the links I used www.rfc-editor.org instead of tools.ietf.org, I can change this if needed.

I tried testing locally, but had issues running the test server, so I'm hoping CI tests will pass once the CI server gets updated.

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added unit tests to accompany this PR.
- [ ] The (new/existing) tests cover this PR 100%.
- [ ] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

## Documentation

For new features:
- [ ] I have added a code example showing how to use this feature to the [`examples`](https://github.com/WordPress/Requests/tree/develop/examples) directory.
- [x] I have added documentation about this feature to the [`docs`](https://github.com/WordPress/Requests/tree/develop/docs) directory.
    If the documentation is in a new markdown file, I have added a link to this new file to the Docs folder [`README.md`](https://github.com/WordPress/Requests/tree/develop/docs/README.md) file.
