### PR TITLE
Skip the SNI test until it can verify SNI again

### DIFF
--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -906,6 +906,11 @@ abstract class BaseTestCase extends TestCase {
 	 * humanmade.com (owned by Human Made and used with permission) points to
 	 * CloudFront, and will fail if SNI isn't sent.
 	 *
+	 * {@internal Skipped for the time being. The above no longer holds: the host serves the
+	 * same certificate whether SNI is sent or not, so a transport which stopped sending it
+	 * would still pass, and the host has meanwhile started refusing requests outright.
+	 * See https://github.com/WordPress/Requests/issues/1077.}
+	 *
 	 * @dataProvider dataSNISupport
 	 *
 	 * @param array $options Additional options to pass.
@@ -913,6 +918,11 @@ abstract class BaseTestCase extends TestCase {
 	 * @return void
 	 */
 	public function testSNISupport($options) {
+		$this->markTestSkipped(
+			'This test does not verify SNI support anymore.'
+			. ' See https://github.com/WordPress/Requests/issues/1077'
+		);
+
 		if ($this->skip_https) {
 			$this->markTestSkipped('SSL support is not available.');
 			return;


### PR DESCRIPTION
`testSNISupport` requests an HTTPS host and expects a `200`, which only demonstrates something if that host serves a *different* certificate when no SNI is sent. It no longer does, so a transport which quietly stopped sending SNI would still pass the test.

On top of that, the host it uses now answers `403` to every client, including a plain `curl`, so the test currently fails for reasons which have nothing to do with the library. That is what brought this to light.

Repointing it at another host would get the suite green again, but it would leave a test standing which looks like it covers something it does not. Skipping it states what is actually the case, and keeps the intent visible for whoever picks it up. The original docblock stays, with a note explaining the situation, and both the note and the skip message link to the issue.

Details, including the certificate comparison across several hosts and the options for getting real coverage back, are in #1077.

Refs #1077
