### PR TITLE
Restore SNI coverage with a local TLS fixture

### DIFF
--- a/tests/Fixtures/SniServer.php
+++ b/tests/Fixtures/SniServer.php
@@ -83,6 +83,11 @@ final class SniServer {
 	 * @throws \RuntimeException If the certificate or server setup fails.
 	 */
 	public function __construct() {
+		$unsupported_reason = self::getUnsupportedReason();
+		if ($unsupported_reason !== null) {
+			throw new \RuntimeException($unsupported_reason);
+		}
+
 		$this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'requests-sni-' . uniqid('', true);
 
 		if (!mkdir($this->directory, 0700, true)) {
@@ -96,6 +101,37 @@ final class SniServer {
 			$this->close();
 			throw $exception;
 		}
+	}
+
+	/**
+	 * Get the reason why the local SNI server cannot run, if any.
+	 *
+	 * @return string|null
+	 */
+	public static function getUnsupportedReason() {
+		$required_functions = [
+			'openssl_pkey_new',
+			'openssl_csr_new',
+			'openssl_csr_sign',
+			'openssl_x509_export',
+			'openssl_pkey_export',
+			'proc_open',
+			'proc_close',
+			'proc_get_status',
+			'proc_terminate',
+		];
+
+		foreach ($required_functions as $function) {
+			if (!function_exists($function)) {
+				return sprintf('The SNI test requires the PHP function %s.', $function);
+			}
+		}
+
+		if (self::findPython() === null) {
+			return 'The SNI test requires Python 3. Set REQUESTS_SNI_PYTHON to override the executable.';
+		}
+
+		return null;
 	}
 
 	/**
@@ -183,10 +219,6 @@ final class SniServer {
 	 * @throws \RuntimeException If OpenSSL cannot create the certificates.
 	 */
 	private function createCertificates() {
-		if (!function_exists('openssl_pkey_new') || !function_exists('openssl_csr_new')) {
-			throw new \RuntimeException('The OpenSSL extension is required for the SNI test.');
-		}
-
 		$config_file = $this->directory . DIRECTORY_SEPARATOR . 'openssl.cnf';
 		$config      = "[req]\n";
 		$config     .= "prompt = no\n";
@@ -346,9 +378,9 @@ final class SniServer {
 	 * @throws \RuntimeException If the endpoint cannot be started.
 	 */
 	private function startServer() {
-		$python = getenv('REQUESTS_SNI_PYTHON');
-		if ($python === false || $python === '') {
-			$python = 'python3';
+		$python = self::findPython();
+		if ($python === null) {
+			throw new \RuntimeException('The SNI test requires Python 3. Set REQUESTS_SNI_PYTHON to override the executable.');
 		}
 
 		$script   = __DIR__ . DIRECTORY_SEPARATOR . 'sni_server.py';
@@ -382,7 +414,7 @@ final class SniServer {
 				$this->server_output .= $output;
 			}
 
-			if (preg_match('/(?:^|\n)PORT=(\d+)(?:\n|$)/', $this->server_output, $matches)) {
+			if (preg_match('/(?:^|\r?\n)PORT=(\d+)(?:\r?\n|$)/', $this->server_output, $matches)) {
 				$port = (int) $matches[1];
 				break;
 			}
@@ -412,5 +444,54 @@ final class SniServer {
 		}
 
 		$this->url = 'https://localhost:' . $port . '/';
+	}
+
+	/**
+	 * Find a usable Python 3 executable.
+	 *
+	 * @return string|null
+	 */
+	private static function findPython() {
+		$candidates = [];
+		$configured = getenv('REQUESTS_SNI_PYTHON');
+		if ($configured !== false && $configured !== '') {
+			$candidates[] = $configured;
+		}
+
+		$candidates[] = 'python3';
+		$candidates[] = 'python';
+
+		foreach (array_unique($candidates) as $candidate) {
+			$descriptors = [
+				0 => ['pipe', 'r'],
+				1 => ['pipe', 'w'],
+				2 => ['pipe', 'w'],
+			];
+			$process     = proc_open(escapeshellarg($candidate) . ' --version', $descriptors, $pipes);
+			if (!is_resource($process)) {
+				continue;
+			}
+
+			fclose($pipes[0]);
+			$output = stream_get_contents($pipes[1]);
+			$error  = stream_get_contents($pipes[2]);
+			fclose($pipes[1]);
+			fclose($pipes[2]);
+
+			if ($output === false) {
+				$output = '';
+			}
+
+			if ($error !== false) {
+				$output .= $error;
+			}
+
+			$status = proc_close($process);
+			if ($status === 0 && preg_match('/Python\s+3(?:\.\d+)+/', $output)) {
+				return $candidate;
+			}
+		}
+
+		return null;
 	}
 }

--- a/tests/Fixtures/SniServer.php
+++ b/tests/Fixtures/SniServer.php
@@ -1,0 +1,416 @@
+<?php
+
+namespace WpOrg\Requests\Tests\Fixtures;
+
+/**
+ * Local TLS server used to verify Server Name Indication support.
+ */
+final class SniServer {
+
+	/**
+	 * Temporary directory containing the generated certificates.
+	 *
+	 * @var string
+	 */
+	private $directory;
+
+	/**
+	 * Certificate authority file path.
+	 *
+	 * @var string
+	 */
+	private $ca_file;
+
+	/**
+	 * Correct server certificate file path.
+	 *
+	 * @var string
+	 */
+	private $server_certificate;
+
+	/**
+	 * Correct server key file path.
+	 *
+	 * @var string
+	 */
+	private $server_key;
+
+	/**
+	 * Wrong server certificate file path.
+	 *
+	 * @var string
+	 */
+	private $wrong_certificate;
+
+	/**
+	 * Wrong server key file path.
+	 *
+	 * @var string
+	 */
+	private $wrong_key;
+
+	/**
+	 * Running Python server process.
+	 *
+	 * @var resource|null
+	 */
+	private $process;
+
+	/**
+	 * Process pipes.
+	 *
+	 * @var array
+	 */
+	private $pipes = [];
+
+	/**
+	 * Server URL.
+	 *
+	 * @var string
+	 */
+	private $url;
+
+	/**
+	 * Server output captured during startup.
+	 *
+	 * @var string
+	 */
+	private $server_output = '';
+
+	/**
+	 * Start the local TLS server.
+	 *
+	 * @throws \RuntimeException If the certificate or server setup fails.
+	 */
+	public function __construct() {
+		$this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'requests-sni-' . uniqid('', true);
+
+		if (!mkdir($this->directory, 0700, true)) {
+			throw new \RuntimeException('Could not create the SNI test directory.');
+		}
+
+		try {
+			$this->createCertificates();
+			$this->startServer();
+		} catch (\Exception $exception) {
+			$this->close();
+			throw $exception;
+		}
+	}
+
+	/**
+	 * Get the URL served by the local endpoint.
+	 *
+	 * @return string
+	 */
+	public function getUrl() {
+		return $this->url;
+	}
+
+	/**
+	 * Get the CA file used to sign the SNI certificate.
+	 *
+	 * @return string
+	 */
+	public function getCaFile() {
+		return $this->ca_file;
+	}
+
+	/**
+	 * Stop the server and remove generated files.
+	 *
+	 * @return void
+	 */
+	public function close() {
+		if (is_resource($this->process)) {
+			if (isset($this->pipes[0]) && is_resource($this->pipes[0])) {
+				fclose($this->pipes[0]);
+			}
+
+			$status = proc_get_status($this->process);
+			if ($status['running']) {
+				proc_terminate($this->process);
+				$deadline = microtime(true) + 1;
+				do {
+					usleep(10000);
+					$status = proc_get_status($this->process);
+				} while ($status['running'] && microtime(true) < $deadline);
+
+				if ($status['running']) {
+					proc_terminate($this->process, 9);
+				}
+			}
+
+			proc_close($this->process);
+			$this->process = null;
+		}
+
+		foreach ($this->pipes as $pipe) {
+			if (is_resource($pipe)) {
+				fclose($pipe);
+			}
+		}
+
+		$this->pipes = [];
+
+		if ($this->directory !== null && is_dir($this->directory)) {
+			$files = glob($this->directory . DIRECTORY_SEPARATOR . '*');
+			if (is_array($files)) {
+				foreach ($files as $file) {
+					if (is_file($file)) {
+						unlink($file);
+					}
+				}
+			}
+
+			rmdir($this->directory);
+			$this->directory = null;
+		}
+	}
+
+	/**
+	 * Ensure the child process is cleaned up if a test aborts unexpectedly.
+	 */
+	public function __destruct() {
+		$this->close();
+	}
+
+	/**
+	 * Generate a trusted and an untrusted server certificate.
+	 *
+	 * @return void
+	 *
+	 * @throws \RuntimeException If OpenSSL cannot create the certificates.
+	 */
+	private function createCertificates() {
+		if (!function_exists('openssl_pkey_new') || !function_exists('openssl_csr_new')) {
+			throw new \RuntimeException('The OpenSSL extension is required for the SNI test.');
+		}
+
+		$config_file = $this->directory . DIRECTORY_SEPARATOR . 'openssl.cnf';
+		$config      = "[req]\n";
+		$config     .= "prompt = no\n";
+		$config     .= "distinguished_name = distinguished_name\n";
+		$config     .= "req_extensions = server_ext\n\n";
+		$config     .= "[distinguished_name]\n";
+		$config     .= "CN = localhost\n\n";
+		$config     .= "[server_ext]\n";
+		$config     .= "basicConstraints = critical,CA:FALSE\n";
+		$config     .= "keyUsage = critical,digitalSignature,keyEncipherment\n";
+		$config     .= "subjectAltName = DNS:localhost\n\n";
+		$config     .= "[ca_ext]\n";
+		$config     .= "basicConstraints = critical,CA:TRUE,pathlen:1\n";
+		$config     .= "keyUsage = critical,keyCertSign,cRLSign\n";
+		$config     .= "subjectKeyIdentifier = hash\n";
+		$config     .= "authorityKeyIdentifier = keyid:always,issuer\n";
+
+		if (file_put_contents($config_file, $config) === false) {
+			throw new \RuntimeException('Could not write the OpenSSL configuration.');
+		}
+
+		$ca_key = $this->createKey();
+		$ca_csr = openssl_csr_new(['commonName' => 'Requests SNI test CA'], $ca_key, ['digest_alg' => 'sha256']);
+		$ca     = openssl_csr_sign(
+			$ca_csr,
+			null,
+			$ca_key,
+			1,
+			[
+				'config'          => $config_file,
+				'digest_alg'      => 'sha256',
+				'x509_extensions' => 'ca_ext',
+			]
+		);
+
+		if ($ca_csr === false || $ca === false) {
+			throw new \RuntimeException('Could not create the SNI test certificate authority.');
+		}
+
+		$server_key = $this->createKey();
+		$server_csr = openssl_csr_new(
+			['commonName' => 'localhost'],
+			$server_key,
+			[
+				'config'         => $config_file,
+				'digest_alg'     => 'sha256',
+				'req_extensions' => 'server_ext',
+			]
+		);
+		$server     = openssl_csr_sign(
+			$server_csr,
+			$ca,
+			$ca_key,
+			1,
+			[
+				'config'          => $config_file,
+				'digest_alg'      => 'sha256',
+				'x509_extensions' => 'server_ext',
+			]
+		);
+
+		$wrong_key = $this->createKey();
+		$wrong_csr = openssl_csr_new(['commonName' => 'wrong.localhost'], $wrong_key, ['digest_alg' => 'sha256']);
+		$wrong     = openssl_csr_sign($wrong_csr, null, $wrong_key, 1, ['digest_alg' => 'sha256']);
+
+		if ($server_csr === false || $server === false || $wrong_csr === false || $wrong === false) {
+			throw new \RuntimeException('Could not create the SNI test certificates.');
+		}
+
+		$this->ca_file            = $this->writeCertificate($ca, 'ca.pem');
+		$this->server_certificate = $this->writeCertificate($server, 'server.pem');
+		$this->server_key         = $this->writeKey($server_key, 'server-key.pem');
+		$this->wrong_certificate  = $this->writeCertificate($wrong, 'wrong.pem');
+		$this->wrong_key          = $this->writeKey($wrong_key, 'wrong-key.pem');
+	}
+
+	/**
+	 * Create a private key.
+	 *
+	 * @return resource
+	 *
+	 * @throws \RuntimeException If OpenSSL cannot create the key.
+	 */
+	private function createKey() {
+		$key = openssl_pkey_new(
+			[
+				'private_key_type' => OPENSSL_KEYTYPE_RSA,
+				'private_key_bits' => 2048,
+			]
+		);
+
+		if ($key === false) {
+			throw new \RuntimeException('Could not create an SNI test key.');
+		}
+
+		return $key;
+	}
+
+	/**
+	 * Write a certificate to the temporary directory.
+	 *
+	 * @param resource $certificate Certificate resource.
+	 * @param string   $name        File name.
+	 *
+	 * @return string
+	 */
+	private function writeCertificate($certificate, $name) {
+		$pem = '';
+		if (!openssl_x509_export($certificate, $pem)) {
+			throw new \RuntimeException('Could not export an SNI test certificate.');
+		}
+
+		return $this->writeFile($name, $pem);
+	}
+
+	/**
+	 * Write a private key to the temporary directory.
+	 *
+	 * @param resource $key  Private key resource.
+	 * @param string   $name File name.
+	 *
+	 * @return string
+	 */
+	private function writeKey($key, $name) {
+		$pem = '';
+		if (!openssl_pkey_export($key, $pem)) {
+			throw new \RuntimeException('Could not export an SNI test key.');
+		}
+
+		return $this->writeFile($name, $pem);
+	}
+
+	/**
+	 * Write a temporary file.
+	 *
+	 * @param string $name    File name.
+	 * @param string $contents File contents.
+	 *
+	 * @return string
+	 */
+	private function writeFile($name, $contents) {
+		$path = $this->directory . DIRECTORY_SEPARATOR . $name;
+		if (file_put_contents($path, $contents) === false) {
+			throw new \RuntimeException('Could not write an SNI test file.');
+		}
+
+		return $path;
+	}
+
+	/**
+	 * Start the Python TLS endpoint.
+	 *
+	 * The Python executable can be overridden with REQUESTS_SNI_PYTHON.
+	 *
+	 * @return void
+	 *
+	 * @throws \RuntimeException If the endpoint cannot be started.
+	 */
+	private function startServer() {
+		$python = getenv('REQUESTS_SNI_PYTHON');
+		if ($python === false || $python === '') {
+			$python = 'python3';
+		}
+
+		$script   = __DIR__ . DIRECTORY_SEPARATOR . 'sni_server.py';
+		$command  = escapeshellarg($python);
+		$command .= ' ' . escapeshellarg($script);
+		$command .= ' --correct-cert ' . escapeshellarg($this->server_certificate);
+		$command .= ' --correct-key ' . escapeshellarg($this->server_key);
+		$command .= ' --wrong-cert ' . escapeshellarg($this->wrong_certificate);
+		$command .= ' --wrong-key ' . escapeshellarg($this->wrong_key);
+		$command .= ' --expected-name localhost';
+
+		$descriptors   = [
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+		$this->process = proc_open($command, $descriptors, $this->pipes);
+
+		if (!is_resource($this->process)) {
+			throw new \RuntimeException('Could not start the SNI test server.');
+		}
+
+		stream_set_blocking($this->pipes[1], false);
+		stream_set_blocking($this->pipes[2], false);
+
+		$port     = null;
+		$deadline = microtime(true) + 15;
+		while (microtime(true) < $deadline) {
+			$output = stream_get_contents($this->pipes[1]);
+			if ($output !== false) {
+				$this->server_output .= $output;
+			}
+
+			if (preg_match('/(?:^|\n)PORT=(\d+)(?:\n|$)/', $this->server_output, $matches)) {
+				$port = (int) $matches[1];
+				break;
+			}
+
+			$status = proc_get_status($this->process);
+			if (!$status['running']) {
+				break;
+			}
+
+			usleep(10000);
+		}
+
+		if ($port === null) {
+			$error  = stream_get_contents($this->pipes[2]);
+			$output = trim($this->server_output);
+			$this->close();
+			$message = 'The SNI test server did not start.';
+			if ($output !== '') {
+				$message .= ' Output: ' . $output;
+			}
+
+			if ($error !== false && trim($error) !== '') {
+				$message .= ' Error: ' . trim($error);
+			}
+
+			throw new \RuntimeException($message);
+		}
+
+		$this->url = 'https://localhost:' . $port . '/';
+	}
+}

--- a/tests/Fixtures/sni_server.py
+++ b/tests/Fixtures/sni_server.py
@@ -1,0 +1,95 @@
+import argparse
+import socket
+import ssl
+import sys
+
+
+SERVER_TIMEOUT = 15
+
+
+def create_context(certificate, key):
+    protocol = getattr(ssl, "PROTOCOL_TLS_SERVER", ssl.PROTOCOL_TLS)
+    context = ssl.SSLContext(protocol)
+    context.load_cert_chain(certificate, key)
+    return context
+
+
+def create_listener(port):
+    if socket.has_ipv6:
+        try:
+            listener = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            v6_only = getattr(socket, "IPV6_V6ONLY", None)
+            if v6_only is not None:
+                listener.setsockopt(socket.IPPROTO_IPV6, v6_only, 0)
+            listener.bind(("::", port))
+            return listener
+        except OSError:
+            if "listener" in locals():
+                listener.close()
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", port))
+    return listener
+
+
+def serve(arguments):
+    correct_context = create_context(arguments.correct_cert, arguments.correct_key)
+    wrong_context = create_context(arguments.wrong_cert, arguments.wrong_key)
+
+    def select_certificate(ssl_socket, server_name, _context):
+        if server_name == arguments.expected_name:
+            ssl_socket.context = correct_context
+
+    wrong_context.set_servername_callback(select_certificate)
+
+    listener = create_listener(arguments.port)
+    listener.listen(1)
+    listener.settimeout(SERVER_TIMEOUT)
+
+    try:
+        print("PORT={}".format(listener.getsockname()[1]), flush=True)
+        connection, _address = listener.accept()
+        try:
+            secure_connection = wrong_context.wrap_socket(connection, server_side=True)
+            with secure_connection:
+                request = b""
+                while b"\r\n\r\n" not in request and len(request) < 65536:
+                    chunk = secure_connection.recv(4096)
+                    if not chunk:
+                        break
+                    request += chunk
+
+                if request:
+                    secure_connection.sendall(
+                        b"HTTP/1.1 200 OK\r\n"
+                        b"Content-Length: 0\r\n"
+                        b"Connection: close\r\n\r\n"
+                    )
+        except (OSError, ssl.SSLError) as error:
+            print("{}: {}".format(type(error).__name__, error), file=sys.stderr)
+            return 1
+    except socket.timeout:
+        print("Timed out waiting for the SNI test request.", file=sys.stderr)
+        return 1
+    finally:
+        listener.close()
+
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--correct-cert", required=True)
+    parser.add_argument("--correct-key", required=True)
+    parser.add_argument("--wrong-cert", required=True)
+    parser.add_argument("--wrong-key", required=True)
+    parser.add_argument("--expected-name", required=True)
+    parser.add_argument("--port", type=int, default=0)
+    arguments = parser.parse_args()
+    return serve(arguments)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Fixtures/sni_server.py
+++ b/tests/Fixtures/sni_server.py
@@ -22,7 +22,7 @@ def create_listener(port):
             v6_only = getattr(socket, "IPV6_V6ONLY", None)
             if v6_only is not None:
                 listener.setsockopt(socket.IPPROTO_IPV6, v6_only, 0)
-            listener.bind(("::", port))
+            listener.bind(("::1", port))
             return listener
         except OSError:
             if "listener" in locals():
@@ -45,13 +45,15 @@ def serve(arguments):
     wrong_context.set_servername_callback(select_certificate)
 
     listener = create_listener(arguments.port)
-    listener.listen(1)
-    listener.settimeout(SERVER_TIMEOUT)
 
     try:
+        listener.listen(1)
+        listener.settimeout(SERVER_TIMEOUT)
         print("PORT={}".format(listener.getsockname()[1]), flush=True)
-        connection, _address = listener.accept()
+        connection = None
         try:
+            connection, _address = listener.accept()
+            connection.settimeout(SERVER_TIMEOUT)
             secure_connection = wrong_context.wrap_socket(connection, server_side=True)
             with secure_connection:
                 request = b""
@@ -70,6 +72,9 @@ def serve(arguments):
         except (OSError, ssl.SSLError) as error:
             print("{}: {}".format(type(error).__name__, error), file=sys.stderr)
             return 1
+        finally:
+            if connection is not None:
+                connection.close()
     except socket.timeout:
         print("Timed out waiting for the SNI test request.", file=sys.stderr)
         return 1

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -10,6 +10,7 @@ use WpOrg\Requests\Hooks;
 use WpOrg\Requests\Iri;
 use WpOrg\Requests\Requests;
 use WpOrg\Requests\Response;
+use WpOrg\Requests\Tests\Fixtures\SniServer;
 use WpOrg\Requests\Tests\Fixtures\TransportMock;
 use WpOrg\Requests\Tests\TestCase;
 use WpOrg\Requests\Tests\TypeProviderHelper;
@@ -901,15 +902,12 @@ abstract class BaseTestCase extends TestCase {
 	}
 
 	/**
-	 * Test that the transport supports Server Name Indication with HTTPS
+	 * Test that the transport sends Server Name Indication with HTTPS.
 	 *
-	 * humanmade.com (owned by Human Made and used with permission) points to
-	 * CloudFront, and will fail if SNI isn't sent.
-	 *
-	 * {@internal Skipped for the time being. The above no longer holds: the host serves the
-	 * same certificate whether SNI is sent or not, so a transport which stopped sending it
-	 * would still pass, and the host has meanwhile started refusing requests outright.
-	 * See https://github.com/WordPress/Requests/issues/1077.}
+	 * The local test server presents a trusted certificate when SNI is sent
+	 * and an untrusted certificate otherwise. This makes the test independent
+	 * of third-party hosts and verifies that SNI remains enabled when hostname
+	 * verification is disabled.
 	 *
 	 * @dataProvider dataSNISupport
 	 *
@@ -918,18 +916,20 @@ abstract class BaseTestCase extends TestCase {
 	 * @return void
 	 */
 	public function testSNISupport($options) {
-		$this->markTestSkipped(
-			'This test does not verify SNI support anymore.'
-			. ' See https://github.com/WordPress/Requests/issues/1077'
-		);
-
 		if ($this->skip_https) {
 			$this->markTestSkipped('SSL support is not available.');
 			return;
 		}
 
-		$request = Requests::head('https://humanmade.com/', [], $this->getOptions($options));
-		$this->assertSame(200, $request->status_code);
+		$server = new SniServer();
+
+		try {
+			$options['verify'] = $server->getCaFile();
+			$request           = Requests::head($server->getUrl(), [], $this->getOptions($options));
+			$this->assertSame(200, $request->status_code);
+		} finally {
+			$server->close();
+		}
 	}
 
 	/**

--- a/tests/Transport/BaseTestCase.php
+++ b/tests/Transport/BaseTestCase.php
@@ -921,6 +921,12 @@ abstract class BaseTestCase extends TestCase {
 			return;
 		}
 
+		$unsupported_reason = SniServer::getUnsupportedReason();
+		if ($unsupported_reason !== null) {
+			$this->markTestSkipped($unsupported_reason);
+			return;
+		}
+
 		$server = new SniServer();
 
 		try {


### PR DESCRIPTION
## Pull Request Type

- [x] I have checked there is no other PR open for the same change.

This is a:
- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Code quality improvement

## Context

The existing `testSNISupport` test relied on a public third-party host whose certificate is now the same with and without SNI. As a result, the test no longer verifies the behavior it was intended to cover and had been skipped.

This change restores meaningful SNI coverage for issue #1077 without depending on a public endpoint or its current TLS configuration.

## Detailed Description

- Replace the skipped public-host check with a local HTTPS endpoint.
- Generate an ephemeral test CA, a trusted `localhost` certificate, and an untrusted fallback certificate during the test.
- Start a small Python standard-library TLS server which selects the trusted certificate only when the client sends SNI for `localhost`.
- Exercise both transport implementations and the existing `verifyname` option variants through the current data provider.
- Close the child process and remove temporary key and certificate files after each test.

The helper uses Python 3 from the test environment and has no third-party Python dependency.

## Quality assurance

- [x] This change does NOT contain a breaking change (fix or feature that would cause existing functionality to change).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added unit tests to accompany this PR.
- [x] The (new/existing) tests cover this PR 100%.
- [x] I have (manually) tested this code to the best of my abilities.
- [x] My code follows the style guidelines of this project.

Validation performed:

- PHP 8.3.6 / PHPUnit 10.5.64: 6 tests passed.
- PHP 5.6.40 / PHPUnit 5.7.27: 6 tests passed in each of three runs, 18/18 total.
- PHPCS passed for the changed PHP files.
- PHP parallel-lint passed for the changed PHP files.
- Python bytecode compilation passed for the TLS helper.
- `git diff --check` passed.

Fixes #1077

<details>

<summary>AI Disclaimer</summary>

This pull request was primarily developed with assistance from OpenAI Codex, an AI coding agent. For this PR, Codex analyzed issue #1077, inspected the relevant Requests transport tests, implemented the local TLS/SNI fixture, and ran the reported validation commands under the supervision of `jmtdev0`.

Human involvement in this PR was very low.

If you do not agree with the use of AI assistance or with the level of human involvement in this PR, please feel free to disregard it, close it, or request changes. I will fully respect that decision.

</details>
